### PR TITLE
feat: implement Epola GNOME App Store with Flatpak support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Epola
+
+Epola es la tienda de aplicaciones moderna para NemasOS, diseñada con GTK4 y Libadwaita.
+
+## Requisitos del Sistema
+
+Para compilar y ejecutar Epola desde el código fuente, necesitarás:
+
+- Python 3
+- Meson
+- Ninja
+- Blueprint Compiler
+- Libadwaita (desarrollo)
+- GObject Introspection para Python (`python3-gi`)
+- PackageKit, Flatpak y/o Snap (para la gestión de paquetes)
+
+## Compilación e Instalación
+
+### Usando GNOME Builder (Recomendado)
+
+1. Abre GNOME Builder.
+2. Selecciona "Abrir un proyecto" y elige la carpeta de Epola.
+3. Builder detectará automáticamente el archivo `tte.nemas.Epola.json` y configurará el entorno Flatpak.
+4. Haz clic en el botón de "Reproducir" (Ejecutar) para compilar y lanzar la aplicación.
+
+### Manualmente (Meson)
+
+```bash
+# Configurar el directorio de construcción
+meson setup builddir
+
+# Compilar
+meson compile -C builddir
+
+# Instalar (requiere privilegios de root)
+sudo meson install -C builddir
+```
+
+## Estructura del Proyecto
+
+- `src/`: Lógica de la aplicación en Python.
+- `data/`: Interfaces (Blueprint), esquemas de configuración y metadatos.
+- `po/`: Archivos de traducción.
+- `tte.nemas.Epola.json`: Manifiesto Flatpak.
+
+## Características
+
+- Interfaz moderna y adaptativa.
+- Soporte para Flatpak, Snap y paquetes nativos (PackageKit).
+- Asistente de configuración inicial (Setup Wizard).
+- Grillas de aplicaciones con widgets elegantes.
+- Animaciones fluidas.
+```

--- a/src/main.py
+++ b/src/main.py
@@ -6,15 +6,27 @@ from gi.repository import Gtk, Gio, Adw, Gdk
 
 # Handle package name and path
 APP_ID = 'tte.nemas.Epola'
-PKGDATADIR = os.environ.get('PKGDATADIR', os.path.join(os.path.dirname(__file__), '..', 'data'))
+
+# Logic for finding data dir
+PKGDATADIR = os.environ.get('PKGDATADIR')
+if not PKGDATADIR:
+    # Try common locations
+    for path in ['/app/share/tte.nemas.Epola', '/usr/local/share/tte.nemas.Epola', '/usr/share/tte.nemas.Epola']:
+        if os.path.exists(path):
+            PKGDATADIR = path
+            break
+if not PKGDATADIR:
+    # Fallback to local development path
+    PKGDATADIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../data'))
 
 # Initialize gettext
 gettext.bindtextdomain(APP_ID, os.path.join(PKGDATADIR, 'locale'))
 gettext.textdomain(APP_ID)
 _ = gettext.gettext
 
-from .window import EpolaWindow
-from .setup import EpolaSetupWindow
+# Local imports
+from window import EpolaWindow
+from setup import EpolaSetupWindow
 
 class EpolaApplication(Adw.Application):
     def __init__(self):
@@ -45,6 +57,12 @@ class EpolaApplication(Adw.Application):
     def do_startup(self):
         Adw.Application.do_startup(self)
 
+        # Load resources
+        resource_file = os.path.join(PKGDATADIR, 'tte.nemas.Epola.gresource')
+        if os.path.exists(resource_file):
+            resource = Gio.Resource.load(resource_file)
+            resource._register()
+
         # Load CSS
         provider = Gtk.CssProvider()
         try:
@@ -57,29 +75,12 @@ class EpolaApplication(Adw.Application):
         except Exception as e:
             print(f"Could not load CSS: {e}")
 
-        # Load resources
-        resource_file = os.path.join(PKGDATADIR, 'tte.nemas.Epola.gresource')
-        if not os.path.exists(resource_file):
-             # Fallback for development structure
-             resource_file = os.path.join(os.path.dirname(__file__), '..', 'data', 'tte.nemas.Epola.gresource')
-
-        if os.path.exists(resource_file):
-            resource = Gio.Resource.load(resource_file)
-            resource._register()
-
 def main():
     app = EpolaApplication()
     return app.run(sys.argv)
 
 if __name__ == '__main__':
-    # Add parent dir to path so we can do 'from . import ...' if run as script
-    # but it's better to run as a module.
-    # For now, this helper allows running directly.
-    if __package__ is None:
-        path = os.path.dirname(os.path.dirname(__file__))
-        sys.path.insert(0, path)
-        import src
-        __package__ = "src"
-
+    # Add src to path for direct execution
+    sys.path.insert(0, os.path.dirname(__file__))
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     sys.exit(main())

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,5 @@
 pkgdatadir = get_option('prefix') / get_option('datadir') / meson.project_name()
-moduledir = pkgdatadir / 'tte/nemas/Epola'
+moduledir = pkgdatadir / 'epola'
 
 conf = configuration_data()
 conf.set('PYTHON', py_installation.path())
@@ -21,6 +21,7 @@ epola_sources = [
   'setup.py',
   'package_manager.py',
   'const.py',
+  '__init__.py',
 ]
 
 install_data(epola_sources, install_dir: moduledir)

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,5 +1,5 @@
 from gi.repository import Gtk, Adw, GLib, Gio
-from .const import APP_ID
+from const import APP_ID
 
 @Gtk.Template(resource_path='/tte/nemas/Epola/setup.ui')
 class EpolaSetupWindow(Adw.Window):

--- a/src/tte.nemas.Epola.in
+++ b/src/tte.nemas.Epola.in
@@ -1,4 +1,4 @@
 #!/bin/sh
 export PKGDATADIR=@pkgdatadir@
-export PYTHONPATH=$PKGDATADIR:$PYTHONPATH
-exec @PYTHON@ $PKGDATADIR/tte/nemas/Epola/main.py "$@"
+export PYTHONPATH=@pkgdatadir@/epola:$PYTHONPATH
+exec @PYTHON@ @pkgdatadir@/epola/main.py "$@"

--- a/src/window.py
+++ b/src/window.py
@@ -1,5 +1,5 @@
 from gi.repository import Gtk, Adw, GLib, Gio, GObject
-from .package_manager import PackageManager
+from package_manager import PackageManager
 
 @Gtk.Template(resource_path='/tte/nemas/Epola/app_widget.ui')
 class EpolaAppWidget(Gtk.Box):
@@ -48,7 +48,7 @@ class EpolaWindow(Adw.ApplicationWindow):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        from .const import APP_ID
+        from const import APP_ID
         self.settings = Gio.Settings.new(APP_ID)
         self.settings.bind("auto-updates", self.auto_updates_switch, "active", Gio.SettingsBindFlags.DEFAULT)
         self.settings.bind("use-flatpak", self.flatpak_switch, "active", Gio.SettingsBindFlags.DEFAULT)

--- a/tte.nemas.Epola.json
+++ b/tte.nemas.Epola.json
@@ -1,0 +1,54 @@
+{
+    "app-id" : "tte.nemas.Epola",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "47",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "tte.nemas.Epola",
+    "finish-args" : [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--socket=wayland",
+        "--filesystem=home",
+        "--talk-name=org.freedesktop.PackageKit",
+        "--talk-name=org.freedesktop.Flatpak",
+        "--talk-name=io.snapcraft.Launcher"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/man",
+        "/share/man",
+        "/share/gtk-doc",
+        "/share/vala",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "blueprint-compiler",
+            "buildsystem" : "meson",
+            "cleanup" : [ "*" ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
+                    "tag" : "v0.16.0"
+                }
+            ]
+        },
+        {
+            "name" : "epola",
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "dir",
+                    "path" : "."
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
- Rebuilt the app store for GNOME using GTK4, Libadwaita, and Blueprint.
- Established a professional project structure with Meson and Flatpak manifest.
- Implemented real package management for Flatpak, Snap, and PackageKit.
- Added a First Run Wizard for initial setup and theme configuration.
- Integrated GSettings for persistent configuration.
- Added a README.md with detailed build instructions.
- Cleaned up all legacy TPT and Plasma-related files.