### PR TITLE
Fix Meson pkgdatadir scope, guarded post-install, and package backend logging

### DIFF
--- a/build-aux/post_install.py
+++ b/build-aux/post_install.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_if_available(cmd: list[str]) -> None:
+    exe = shutil.which(cmd[0])
+    if not exe:
+        return
+    subprocess.run([exe, *cmd[1:]], check=False)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: post_install.py <prefix> <datadir>", file=sys.stderr)
+        return 1
+
+    prefix, datadir = sys.argv[1], sys.argv[2]
+    share_dir = Path(prefix) / datadir
+
+    schema_dir = share_dir / 'glib-2.0' / 'schemas'
+    if schema_dir.is_dir() and any(schema_dir.glob('*.gschema.xml')):
+        run_if_available(['glib-compile-schemas', str(schema_dir)])
+
+    icons_dir = share_dir / 'icons' / 'hicolor'
+    if icons_dir.is_dir():
+        run_if_available(['gtk-update-icon-cache', '-qtf', str(icons_dir)])
+
+    applications_dir = share_dir / 'applications'
+    if applications_dir.is_dir():
+        run_if_available(['update-desktop-database', str(applications_dir)])
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/meson.build
+++ b/meson.build
@@ -9,19 +9,22 @@ gnome = import('gnome')
 
 python = import('python')
 py_installation = python.find_installation('python3')
+pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
 
 conf = configuration_data()
 conf.set('APP_ID', 'tte.nemas.Epola')
 conf.set('VERSION', meson.project_version())
-conf.set('PYTHON', py_installation.path())
-conf.set('pkgdatadir', join_paths(get_option('prefix'), get_option('datadir'), meson.project_name()))
+conf.set('PYTHON', py_installation.full_path())
+conf.set('pkgdatadir', pkgdatadir)
 
 subdir('data')
 subdir('src')
 subdir('po')
 
-gnome.post_install(
-     glib_compile_schemas: true,
-    gtk_update_icon_cache: true,
-  update_desktop_database: true,
+python3 = find_program('python3')
+meson.add_install_script(
+  python3,
+  files('build-aux/post_install.py'),
+  get_option('prefix'),
+  get_option('datadir'),
 )

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@ import sys
 import os
 import signal
 import gettext
+import logging
 from gi.repository import Gtk, Gio, Adw, Gdk
 
 # Handle package name and path
@@ -24,6 +25,8 @@ gettext.bindtextdomain(APP_ID, os.path.join(PKGDATADIR, 'locale'))
 gettext.textdomain(APP_ID)
 _ = gettext.gettext
 
+logging.basicConfig(level=logging.INFO)
+
 # Local imports
 from window import EpolaWindow
 from setup import EpolaSetupWindow
@@ -40,7 +43,8 @@ class EpolaApplication(Adw.Application):
             try:
                 self.settings = Gio.Settings.new(APP_ID)
                 first_run = self.settings.get_boolean('first-run')
-            except:
+            except Exception:
+                logging.exception('No se pudo leer GSettings, asumiendo primer inicio')
                 first_run = True
 
             if first_run:
@@ -73,7 +77,7 @@ class EpolaApplication(Adw.Application):
                 Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
             )
         except Exception as e:
-            print(f"Could not load CSS: {e}")
+            logging.warning('Could not load CSS: %s', e)
 
 def main():
     app = EpolaApplication()

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,7 +2,7 @@ pkgdatadir = get_option('prefix') / get_option('datadir') / meson.project_name()
 moduledir = pkgdatadir / 'epola'
 
 conf = configuration_data()
-conf.set('PYTHON', py_installation.path())
+conf.set('PYTHON', py_installation.full_path())
 conf.set('APP_ID', 'tte.nemas.Epola')
 conf.set('VERSION', meson.project_version())
 conf.set('pkgdatadir', pkgdatadir)
@@ -12,7 +12,8 @@ configure_file(
   output: 'tte.nemas.Epola',
   configuration: conf,
   install: true,
-  install_dir: get_option('bindir')
+  install_dir: get_option('bindir'),
+  install_mode: 'rwxr-xr-x'
 )
 
 epola_sources = [

--- a/src/package_manager.py
+++ b/src/package_manager.py
@@ -1,6 +1,11 @@
+import logging
 import subprocess
 import threading
 from gi.repository import GLib, Gio, GObject
+
+
+LOG = logging.getLogger(__name__)
+
 
 class AppInfo:
     def __init__(self, id, name, summary, icon, backend, installed=False, version=""):
@@ -11,6 +16,7 @@ class AppInfo:
         self.backend = backend
         self.installed = installed
         self.version = version
+
 
 class PackageManager(GObject.Object):
     __gsignals__ = {
@@ -28,53 +34,46 @@ class PackageManager(GObject.Object):
         def _load():
             apps = []
 
-            # Flatpak
             if self.settings.get_boolean('use-flatpak'):
                 try:
-                    if search_term:
-                        cmd = ['flatpak', 'search', '--columns=application,name,description,version,icon', search_term]
-                    else:
-                        cmd = ['flatpak', 'remote-ls', '--columns=application,name,description,version,icon', '--app']
-
+                    cmd = ['flatpak', 'search', '--columns=application,name,description,version,icon', search_term] if search_term else ['flatpak', 'remote-ls', '--columns=application,name,description,version,icon', '--app']
                     res = subprocess.run(cmd, capture_output=True, text=True)
                     if res.returncode == 0:
                         for line in res.stdout.strip().split('\n'):
                             parts = line.split('\t')
                             if len(parts) >= 3:
-                                apps.append(AppInfo(parts[0].strip(), parts[1].strip(), parts[2].strip(),
-                                                   parts[4].strip() if len(parts)>4 else "application-x-executable",
-                                                   "Flatpak", version=parts[3].strip() if len(parts)>3 else ""))
-                except: pass
+                                apps.append(AppInfo(parts[0].strip(), parts[1].strip(), parts[2].strip(), parts[4].strip() if len(parts) > 4 else 'application-x-executable', 'Flatpak', version=parts[3].strip() if len(parts) > 3 else ''))
+                    else:
+                        LOG.warning('flatpak command failed: %s', res.stderr.strip())
+                except Exception as exc:
+                    LOG.exception('Failed to load Flatpak apps: %s', exc)
 
-            # Snap
             if self.settings.get_boolean('use-snap'):
                 try:
                     if search_term:
-                        cmd = ['snap', 'find', search_term]
-                        res = subprocess.run(cmd, capture_output=True, text=True)
+                        res = subprocess.run(['snap', 'find', search_term], capture_output=True, text=True)
                         if res.returncode == 0:
                             lines = res.stdout.strip().split('\n')
                             if len(lines) > 1:
                                 for line in lines[1:]:
                                     parts = line.split()
                                     if len(parts) >= 1:
-                                        apps.append(AppInfo(parts[0], parts[0], " ".join(parts[3:]) if len(parts)>3 else "", "snap", "Snap"))
-                except: pass
+                                        apps.append(AppInfo(parts[0], parts[0], ' '.join(parts[3:]) if len(parts) > 3 else '', 'snap', 'Snap'))
+                        else:
+                            LOG.warning('snap find failed: %s', res.stderr.strip())
+                except Exception as exc:
+                    LOG.exception('Failed to load Snap apps: %s', exc)
 
-            # PackageKit (pkcon)
             if self.settings.get_boolean('use-packagekit'):
                 try:
                     if search_term:
-                        cmd = ['pkcon', 'search', 'name', search_term]
-                        res = subprocess.run(cmd, capture_output=True, text=True)
+                        res = subprocess.run(['pkcon', 'search', 'name', search_term], capture_output=True, text=True)
                         if res.returncode == 0:
                             current_pkg = {}
                             for line in res.stdout.split('\n'):
                                 if line.startswith('Available') or line.startswith('Installed'):
                                     if 'id' in current_pkg:
-                                        apps.append(AppInfo(current_pkg['id'], current_pkg['name'],
-                                                            current_pkg.get('summary', ''), 'system-software-install',
-                                                            'PackageKit', current_pkg['installed']))
+                                        apps.append(AppInfo(current_pkg['id'], current_pkg['name'], current_pkg.get('summary', ''), 'system-software-install', 'PackageKit', current_pkg['installed']))
                                     current_pkg = {'installed': line.startswith('Installed')}
                                 elif ':' in line:
                                     k, v = line.split(':', 1)
@@ -85,27 +84,33 @@ class PackageManager(GObject.Object):
                                     elif k == 'summary':
                                         current_pkg['summary'] = v
                             if 'id' in current_pkg:
-                                apps.append(AppInfo(current_pkg['id'], current_pkg['name'],
-                                                    current_pkg.get('summary', ''), 'system-software-install',
-                                                    'PackageKit', current_pkg['installed']))
-                except: pass
+                                apps.append(AppInfo(current_pkg['id'], current_pkg['name'], current_pkg.get('summary', ''), 'system-software-install', 'PackageKit', current_pkg['installed']))
+                        else:
+                            LOG.warning('pkcon search failed: %s', res.stderr.strip())
+                except Exception as exc:
+                    LOG.exception('Failed to load PackageKit apps: %s', exc)
 
             GLib.idle_add(self.emit, 'apps-loaded', apps)
+
         threading.Thread(target=_load, daemon=True).start()
 
     def load_installed_apps(self):
         def _load():
             apps = []
-            # Flatpak
             try:
                 res = subprocess.run(['flatpak', 'list', '--columns=application,name,description,version,icon', '--app'], capture_output=True, text=True)
                 if res.returncode == 0:
                     for line in res.stdout.strip().split('\n'):
                         parts = line.split('\t')
                         if len(parts) >= 2:
-                            apps.append(AppInfo(parts[0], parts[1], parts[2] if len(parts)>2 else "", parts[4] if len(parts)>4 else "application-x-executable", "Flatpak", True))
-            except: pass
+                            apps.append(AppInfo(parts[0], parts[1], parts[2] if len(parts) > 2 else '', parts[4] if len(parts) > 4 else 'application-x-executable', 'Flatpak', True))
+                else:
+                    LOG.warning('flatpak list failed: %s', res.stderr.strip())
+            except Exception as exc:
+                LOG.exception('Failed to load installed apps: %s', exc)
+
             GLib.idle_add(self.emit, 'installed-loaded', apps)
+
         threading.Thread(target=_load, daemon=True).start()
 
     def check_updates(self):
@@ -117,28 +122,42 @@ class PackageManager(GObject.Object):
                     for line in res.stdout.strip().split('\n'):
                         parts = line.split('\t')
                         if len(parts) >= 2:
-                            updates.append(AppInfo(parts[0], parts[1], "Actualización disponible", "software-update-available", "Flatpak", True, version=parts[2] if len(parts)>2 else ""))
-            except: pass
+                            updates.append(AppInfo(parts[0], parts[1], 'Actualización disponible', 'software-update-available', 'Flatpak', True, version=parts[2] if len(parts) > 2 else ''))
+                else:
+                    LOG.warning('flatpak remote-ls --updates failed: %s', res.stderr.strip())
+            except Exception as exc:
+                LOG.exception('Failed to check updates: %s', exc)
+
             GLib.idle_add(self.emit, 'updates-loaded', updates)
+
         threading.Thread(target=_load, daemon=True).start()
 
     def install_app(self, app_id, backend):
         def _install():
             success = False
+            error_message = ''
+
             try:
-                if backend == "Flatpak":
-                    # Try user install first to avoid auth prompt if possible
-                    res = subprocess.run(['flatpak', 'install', '--user', '-y', app_id], capture_output=True)
+                if backend == 'Flatpak':
+                    res = subprocess.run(['flatpak', 'install', '--user', '-y', app_id], capture_output=True, text=True)
                     if res.returncode != 0:
-                        res = subprocess.run(['flatpak', 'install', '-y', app_id], capture_output=True)
+                        res = subprocess.run(['flatpak', 'install', '-y', app_id], capture_output=True, text=True)
                     success = res.returncode == 0
-                elif backend == "Snap":
-                    # Use pkexec for snap since it needs root
-                    res = subprocess.run(['pkexec', 'snap', 'install', app_id], capture_output=True)
+                    error_message = res.stderr.strip() if not success else ''
+                elif backend == 'Snap':
+                    res = subprocess.run(['pkexec', 'snap', 'install', app_id], capture_output=True, text=True)
                     success = res.returncode == 0
-                elif backend == "PackageKit":
-                    res = subprocess.run(['pkcon', 'install', '-y', app_id], capture_output=True)
+                    error_message = res.stderr.strip() if not success else ''
+                elif backend == 'PackageKit':
+                    res = subprocess.run(['pkcon', 'install', '-y', app_id], capture_output=True, text=True)
                     success = res.returncode == 0
-            except: pass
-            GLib.idle_add(self.emit, 'operation-completed', success, "")
+                    error_message = res.stderr.strip() if not success else ''
+                else:
+                    error_message = f'Backend no soportado: {backend}'
+            except Exception as exc:
+                error_message = str(exc)
+                LOG.exception('Failed to install app %s with backend %s: %s', app_id, backend, exc)
+
+            GLib.idle_add(self.emit, 'operation-completed', success, error_message)
+
         threading.Thread(target=_install, daemon=True).start()


### PR DESCRIPTION
### Motivation
- `data/meson.build` referenced `pkgdatadir` but the variable was not defined in the top-level scope, causing Meson regeneration to fail with `Unknown variable "pkgdatadir"`.
- Meson external program API used the deprecated `path()` accessor which emits deprecation warnings in newer Meson versions.
- Unconditional post-install actions and many silent `except: pass` blocks hid real failures during install and backend operations, making debugging hard.

### Description
- Define `pkgdatadir` in the top-level `meson.build` before `subdir('data')` so subprojects can reference it via `conf` and `pkgdatadir`.
- Replace deprecated `py_installation.path()` with `py_installation.full_path()` in `meson.build` and `src/meson.build`.
- Replace the unconditional `gnome.post_install(...)` with a guarded install script via `meson.add_install_script(...)` and add `build-aux/post_install.py` which runs `glib-compile-schemas`, `gtk-update-icon-cache` and `update-desktop-database` only when the target dirs/files exist.
- Harden `src/package_manager.py` by adding `logging` (`LOG`), removing silent `except: pass` blocks, logging exceptions/warnings, using `text=True` for subprocess calls, and propagating backend error text through the `operation-completed` signal; also add minor runtime logging and safer exception handling in `src/main.py` and set `install_mode` in `src/meson.build` for the generated wrapper.

### Testing
- Ran `python3 -m py_compile src/*.py build-aux/post_install.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990b9efddb0832597e33568ff2568ee)